### PR TITLE
Update console messages for copyRomListingToFolder

### DIFF
--- a/R/16_copyRomListingToFolder.R
+++ b/R/16_copyRomListingToFolder.R
@@ -35,17 +35,24 @@ copyRomListingToFolder <- function(.reportOutputUrl, .romReportUrl, .registry, .
   if(.existingFile == 0){
     file.copy(.targetFile,.fileLocation, overwrite = .overwrite)
     message("\nFile copied successfully.")
+    cat("Full URL to destination folder:", .fileLocation)
   } else{
     if(!.overwrite){
       message("\nFile was not overwritten. If you would like to overwrite the file - change the .overwrite parameter to TRUE")
     } else{
+      file.copy(.targetFile,.fileLocation, overwrite = .overwrite)
       message("\nFile was overwritten.")
+      cat("Full URL to destination folder:", .fileLocation)
     }
-    file.copy(.targetFile,.fileLocation, overwrite = .overwrite)
   }
 
 
   
-  # Return the full string URL to the file
-  return(.targetFile)
+  # Return the full string URL to the .targetFile and the destination folder
+  invisible(
+    list(
+      "targetFile" = .targetFile
+      ,"destinationFolder" = .fileLocation
+    )
+  )
 }


### PR DESCRIPTION
- Add console message to copyRomListingToFolder to display the destination folder

- Slight reworking of where the actual "file.copy" code lives

- Return a list of the targetFile and the destinationFolder URLs --- Make this invisible so it doesn't print out the list