### PR TITLE
Remove overwrite from copyRomListingToFolder

### DIFF
--- a/R/16_copyRomListingToFolder.R
+++ b/R/16_copyRomListingToFolder.R
@@ -4,7 +4,7 @@
 #' @param .romReportUrl The url to the location for ROM/CDM to view the listing
 #' @param .registry A text string with the initials of the specific registry ("ad", "ms", "raj", "aa", "pso", "ibd", "nmo")
 #' @param .dataPullDate A date string of the data pull date in the format YYYY-DD-MM (e.g. "2024-01-10")
-#' @param .overwrite Whether or not to overwrite the currently existing report in the CDM/ROM folder (DEFAULT = FALSE)
+#' @param .overwrite (OBSOLETE) Whether or not to overwrite the currently existing report in the CDM/ROM folder (DEFAULT = FALSE)
 #'
 #' @return The full string URL to the location of the Excel file in the new location
 #' 
@@ -33,17 +33,14 @@ copyRomListingToFolder <- function(.reportOutputUrl, .romReportUrl, .registry, .
   
   # Copy the file to the folder
   if(.existingFile == 0){
-    file.copy(.targetFile,.fileLocation, overwrite = .overwrite)
+    file.copy(.targetFile,.fileLocation, overwrite = FALSE)
     message("\nFile copied successfully.")
     cat("Full URL to destination folder:", .fileLocation)
   } else{
-    if(!.overwrite){
-      message("\nFile was not overwritten. If you would like to overwrite the file - change the .overwrite parameter to TRUE")
-    } else{
-      file.copy(.targetFile,.fileLocation, overwrite = .overwrite)
-      message("\nFile was overwritten.")
-      cat("Full URL to destination folder:", .fileLocation)
-    }
+    message("\nFile was NOT overwritten.")
+    message("The functionality to automatically OVERWRITE the existing file has been removed.")
+    message("You must review the existing report in the .exampleRomOutputFolder and manually delete it if you wish to re-output and copy over.")
+    message("Do NOT delete or remove an Excel report that has been filled out by members of the CDM/ROM team.")
   }
 
 

--- a/man/copyRomListingToFolder.Rd
+++ b/man/copyRomListingToFolder.Rd
@@ -21,7 +21,7 @@ copyRomListingToFolder(
 
 \item{.dataPullDate}{A date string of the data pull date in the format YYYY-DD-MM (e.g. "2024-01-10")}
 
-\item{.overwrite}{Whether or not to overwrite the currently existing report in the CDM/ROM folder (DEFAULT = FALSE)}
+\item{.overwrite}{(OBSOLETE) Whether or not to overwrite the currently existing report in the CDM/ROM folder (DEFAULT = FALSE)}
 }
 \value{
 The full string URL to the location of the Excel file in the new location


### PR DESCRIPTION
- Removed .overwrite parameter from copyRomListingToFolder
- Updated/added console message telling user to manually review and delete the Excel file from the ROM folder if they want to re-output

- Decision was made to remove this so as to prevent any chance of "accidentally" overwriting (and thus deleting) any data entry that the CDM/ROM team has done to the Excel files